### PR TITLE
fix: auto login separate route, customer area return

### DIFF
--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -13,6 +13,23 @@ export const registerCustomer = async (req: Request, res: Response): Promise<voi
 }
 
 export const loginCustomer = async (req: Request, res: Response): Promise<void> => {
+  await customerService
+    .loginCustomer(req.body as Login)
+    .then((results) => {
+      const { accessToken } = results
+      res
+        .status(200)
+        .cookie('accessToken', accessToken, {
+          expires: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000),
+          secure: true,
+          httpOnly: true
+        })
+        .json(results)
+    })
+    .catch((error: Error) => errorResponses(res, error, 'loginCustomer'))
+}
+
+export const autoLoginCheck = (req: Request, res: Response): void => {
   const cookies = req.cookies
   const encodedToken = cookies.accessToken as string
 
@@ -24,20 +41,7 @@ export const loginCustomer = async (req: Request, res: Response): Promise<void> 
       accessToken: encodedToken
     })
   } else {
-    await customerService
-      .loginCustomer(req.body as Login)
-      .then((results) => {
-        const { accessToken } = results
-        res
-          .status(200)
-          .cookie('accessToken', accessToken, {
-            expires: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000),
-            secure: true,
-            httpOnly: true
-          })
-          .json(results)
-      })
-      .catch((error: Error) => errorResponses(res, error, 'loginCustomer'))
+    res.json()
   }
 }
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { Router } from 'express'
-import { registerCustomer, loginCustomer, logout } from '@/controllers/customerController'
+import { registerCustomer, loginCustomer, logout, autoLoginCheck } from '@/controllers/customerController'
 import { verifyRegistration } from '@/middlewares/verify'
 
 const router = Router()
@@ -13,5 +13,6 @@ router.use((_req, res, next) => {
 router.post('/register', verifyRegistration.verifyBody, verifyRegistration.verifyEmailNotExist, registerCustomer)
 router.post('/login', loginCustomer)
 router.get('/logout', logout)
+router.get('/auto-login-check', autoLoginCheck)
 
 export default router

--- a/src/routes/customer.ts
+++ b/src/routes/customer.ts
@@ -5,11 +5,6 @@ import { verifyToken } from '@/middlewares/verify'
 
 const router = Router()
 
-// router.use((_req, res, next) => {
-//   res.header('Access-Control-Allow-Headers', 'x-access-token, Origin, Content-Type, Accept')
-//   next()
-// })
-
 router.post('/customer-exists', customerExists)
 router.get('/customer-area', verifyToken.verifyToken, customerArea)
 

--- a/src/services/customerService.ts
+++ b/src/services/customerService.ts
@@ -1,6 +1,6 @@
 import { createCustomer, getCustomerByEmail, getCustomerByPhone, getCustomerById } from '@/db/queries/customer'
 import type { CustomerBody, Login, LoginResponse, CustomerExists, AccessToken } from '@/types/customer'
-import { NotFoundError, InternalError } from '@/utils/httpErrors'
+import { NotFoundError } from '@/utils/httpErrors'
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
 
@@ -47,9 +47,9 @@ export const customerExists = async (body: CustomerExists): Promise<{ emailExist
   return { emailExists: emailExists.length > 0, phoneExists: phoneExists.length > 0 }
 }
 
-export const customerArea = async (token: AccessToken | undefined): Promise<CustomerBody> => {
+export const customerArea = async (token: AccessToken | undefined): Promise<CustomerBody | object> => {
   if (token === undefined) {
-    throw new InternalError(undefined, undefined, 'Request.token is undefined')
+    return {}
   }
 
   const user = await getCustomerById(token.id)

--- a/src/utils/tokenVerification.ts
+++ b/src/utils/tokenVerification.ts
@@ -4,7 +4,7 @@ import { type AccessToken } from '@/types/customer'
 
 export const tokenVerification = (token: string): AccessToken | null => {
   if (token === undefined) {
-    throw new ForbiddenError('No token provided')
+    return null
   }
 
   if (Array.isArray(token)) {


### PR DESCRIPTION
Two issues resolved.
1) the auto login using the login route was no good for checking the token when there wasn't one. It was going to the actual login logic and failing. A separate route is used to check for a token instead of a failed login attempt.
2) customer area with token verification needed to return an empty result rather than throw an error when there was no login previously done (i.e. no token present in cookie).