### PR TITLE
fix: auto login respond with 204 status

### DIFF
--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -4,7 +4,6 @@ import { errorResponses } from '@/utils/httpErrors/errorResponses'
 import { type Error } from '@/types/error'
 import type { CustomerBody, Login, CustomerExists } from '@/types/customer'
 import tokenVerification from '@/utils/tokenVerification'
-import logger from '@/utils/logger'
 
 export const registerCustomer = async (req: Request, res: Response): Promise<void> => {
   await customerService
@@ -25,10 +24,8 @@ export const loginCustomer = async (req: Request, res: Response): Promise<void> 
 }
 
 export const autoLoginCheck = (req: Request, res: Response): void => {
-  logger.info('autoLoginCheck')
   const encodedToken = String(req.headers.authorization).split('Bearer ')[1]
-  logger.info('encodedToken')
-  logger.info(encodedToken)
+
   if (encodedToken !== undefined) {
     const decodedToken = tokenVerification(encodedToken)
 
@@ -37,15 +34,8 @@ export const autoLoginCheck = (req: Request, res: Response): void => {
       accessToken: encodedToken
     })
   } else {
-    logger.info('sending...')
-    const data = { data: 'sent' }
-    logger.info(data)
     res.status(204).json({})
   }
-}
-
-export const logout = (_req: Request, res: Response): void => {
-  res.status(200).clearCookie('accessToken').json({})
 }
 
 export const customerExists = async (req: Request, res: Response): Promise<void> => {

--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -38,9 +38,9 @@ export const autoLoginCheck = (req: Request, res: Response): void => {
     })
   } else {
     logger.info('sending...')
-    const data = { message: 'sent' }
+    const data = { data: 'sent' }
     logger.info(data)
-    res.send(data)
+    res.status(204).json({})
   }
 }
 

--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -4,6 +4,7 @@ import { errorResponses } from '@/utils/httpErrors/errorResponses'
 import { type Error } from '@/types/error'
 import type { CustomerBody, Login, CustomerExists } from '@/types/customer'
 import tokenVerification from '@/utils/tokenVerification'
+import logger from '@/utils/logger'
 
 export const registerCustomer = async (req: Request, res: Response): Promise<void> => {
   await customerService
@@ -34,7 +35,10 @@ export const autoLoginCheck = (req: Request, res: Response): void => {
       accessToken: encodedToken
     })
   } else {
-    res.json({ message: '' })
+    logger.info('sending...')
+    const data = { message: 'sent' }
+    logger.info(data)
+    res.send(data)
   }
 }
 

--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -25,8 +25,10 @@ export const loginCustomer = async (req: Request, res: Response): Promise<void> 
 }
 
 export const autoLoginCheck = (req: Request, res: Response): void => {
+  logger.info('autoLoginCheck')
   const encodedToken = String(req.headers.authorization).split('Bearer ')[1]
-
+  logger.info('encodedToken')
+  logger.info(encodedToken)
   if (encodedToken !== undefined) {
     const decodedToken = tokenVerification(encodedToken)
 

--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -34,7 +34,7 @@ export const autoLoginCheck = (req: Request, res: Response): void => {
       accessToken: encodedToken
     })
   } else {
-    res.json({})
+    res.json({ message: '' })
   }
 }
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { Router } from 'express'
-import { registerCustomer, loginCustomer, logout, autoLoginCheck } from '@/controllers/customerController'
+import { registerCustomer, loginCustomer, autoLoginCheck } from '@/controllers/customerController'
 import { verifyRegistration } from '@/middlewares/verify'
 
 const router = Router()
@@ -12,7 +12,6 @@ const router = Router()
 
 router.post('/register', verifyRegistration.verifyBody, verifyRegistration.verifyEmailNotExist, registerCustomer)
 router.post('/login', loginCustomer)
-router.get('/logout', logout)
 router.get('/auto-login-check', autoLoginCheck)
 
 export default router


### PR DESCRIPTION
When there is no token present, respond with 204 status for the UI to check for a handle to not get a failed fetch .json() parsing. Was only an issue in prod, not seen in dev. Probably wouldn't be an issue for with axios.